### PR TITLE
Update tool

### DIFF
--- a/Editor/com.pierotechnical.buildandpublishtool.editor.asmdef
+++ b/Editor/com.pierotechnical.buildandpublishtool.editor.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "com.pierotechnical.buildandpublishtool.editor",
+    "rootNamespace": "",
+    "references": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Editor/com.pierotechnical.buildandpublishtool.editor.asmdef.meta
+++ b/Editor/com.pierotechnical.buildandpublishtool.editor.asmdef.meta
@@ -1,7 +1,6 @@
 fileFormatVersion: 2
-guid: f2b21b9196f11cd4193839f32ddeb2e8
-folderAsset: yes
-DefaultImporter:
+guid: 600fd692aa0b86b4c9a6dda7e1d02b66
+AssemblyDefinitionImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,14 @@ The Build Automation and Publish Tool is a Unity Editor extension that streamlin
 ## Installation
 
 1. Download or clone the repository into your Unity project's `Packages` folder.
-2. Open Unity and navigate to `Tools > Build Automation and Publish Tool` to open the tool window.
-3. The first time you use the tool, it will ask you to locate the butler.exe executable.
 
+Alternatively, in unity editor inside package manager:
+1. Hit `(+)` and select `Add package from Git URL` 
+2. Paste the `git URL` for this package: https://github.com/PieroTechnical/com.pierotechnical.buildandpublishtool.git and hit `Add`
+
+After installation, navigate to `Tools > Build Automation and Publish Tool` to open the tool window.
+
+*The first time you use the tool, it will ask you to locate the **butler.exe** executable.*
 ## Usage
 
 - **Set Up:** Ensure the Butler executable path is set up correctly. If not, you will be prompted to locate it. Currently, you'll need to make sure that the organization and game name in your Unity Project Settings matches those of your itch.io project (ie. [organization].itch.io/[game name]).


### PR DESCRIPTION
**Observations**
- Adding this package for the first time, I got the following warning for all the scripts in **/Editor** folder:
`'Packages/com.pierotechnical.buildandpublishtool/Editor/ButlerUploader.cs' will not be compiled because it exists outside the Assets folder and does not to belong to any assembly definition file.`, which was due to the fact an **.asmdef** file was missing in the tool; therefore, I included it.
- You forgot to include in the **readme.md** file, that it is also possible to install this tool directly from its git URL(unity 2019+), however I included it as well as some little tweaks.

**Changes made**
- Added assembly definition file to /Editor folder for editor scripts' organization 
- Tweaked readme.md